### PR TITLE
Optimisation: Rush once finded

### DIFF
--- a/kernelFile2.cl
+++ b/kernelFile2.cl
@@ -4,24 +4,26 @@ int compatibleRotation(int generatedType, int rotation, int blockFace);
 
 kernel void kernelFile(global int *faces, global int *facecount, global int *found, global int *xlength, global int *zlength, global int *ymin)
 {
-	int foundHere=1;
-	int i;
-	for(i=0; i < (*facecount); i++)
-	{
-		int tex = getTextureType(get_global_id(0) + faces[i*5] - ((*xlength)/2), get_global_id(1) + (*ymin) + faces[i*5 + 1], get_global_id(2) + faces[i*5+2]- ((*zlength)/2));
-		if(compatibleRotation(tex, faces[i*5 + 4], faces[i*5 + 3])==0)
+	if(found[1] == 0){
+		int foundHere=1;
+		int i;
+		for(i=0; i < (*facecount); i++)
 		{
-			foundHere=0;
-			break;
+			int tex = getTextureType(get_global_id(0) + faces[i*5] - ((*xlength)/2), get_global_id(1) + (*ymin) + faces[i*5 + 1], get_global_id(2) + faces[i*5+2]- ((*zlength)/2));
+			if(compatibleRotation(tex, faces[i*5 + 4], faces[i*5 + 3])==0)
+			{
+				foundHere=0;
+				break;
+			}
 		}
-	}
-	
-	if(foundHere==1)
-	{
-		found[0] = get_global_id(0)- ((*xlength)/2);
-		found[1] = get_global_id(1) + (*ymin);
-		found[2] = get_global_id(2)- ((*zlength)/2);
 		
+		if(foundHere==1)
+		{
+			found[0] = get_global_id(0)- ((*xlength)/2);
+			found[1] = get_global_id(1) + (*ymin);
+			found[2] = get_global_id(2)- ((*zlength)/2);
+			
+		}
 	}
 }
 

--- a/kernelFile3.cl
+++ b/kernelFile3.cl
@@ -4,24 +4,26 @@ int compatibleRotation(int generatedType, int rotation, int blockFace);
 
 kernel void kernelFile(global int *faces, global int *facecount, global int *found, global int *xlength, global int *zlength, global int *ymin)
 {
-	int foundHere=1;
-	int i;
-	for(i=0; i < (*facecount); i++)
-	{
-		int tex = getTextureType(get_global_id(0) + faces[i*5] - ((*xlength)/2), get_global_id(1) + (*ymin) + faces[i*5+1], get_global_id(2) + faces[i*5+2]- ((*zlength)/2));
-		if(compatibleRotation(tex, faces[i*5 + 4], faces[i*5 + 3])==0)
+	if(found[1] == 0){
+		int foundHere=1;
+		int i;
+		for(i=0; i < (*facecount); i++)
 		{
-			foundHere=0;
-			break;
+			int tex = getTextureType(get_global_id(0) + faces[i*5] - ((*xlength)/2), get_global_id(1) + (*ymin) + faces[i*5+1], get_global_id(2) + faces[i*5+2]- ((*zlength)/2));
+			if(compatibleRotation(tex, faces[i*5 + 4], faces[i*5 + 3])==0)
+			{
+				foundHere=0;
+				break;
+			}
 		}
-	}
-	
-	if(foundHere==1)
-	{
-		found[0] = get_global_id(0)- ((*xlength)/2);
-		found[1] = get_global_id(1) + (*ymin);
-		found[2] = get_global_id(2)- ((*zlength)/2);
 		
+		if(foundHere==1)
+		{
+			found[0] = get_global_id(0)- ((*xlength)/2);
+			found[1] = get_global_id(1) + (*ymin);
+			found[2] = get_global_id(2)- ((*zlength)/2);
+			
+		}
 	}
 }
 


### PR DESCRIPTION
To my known its not possible to stop an NDRange once started, so this will try to rush ending by executing calculcation only if there isn't any result finded (because currently you must finish calculation of the whole aera to get the result).
The save is small if allrot is not (for an 50000 by 50000 by 60 aera, 4s was saved of 57s).
But with allroot time jump from 186s to 54s (same result as without allrot).

If we would to do that clean we are suposed to send small workload to the kernel and repeat if not finded (send 10s of work, if result finded print and quit else repeat), but that have a not negligible performance impact (it could be done by creating 2 workload so when one is finish the other is running but still a bit more slow).

Also I check on X and not an a new value because finding a result at X 0 is impossible (that full bedrock) and adding a new value cost a few µs per seconds.